### PR TITLE
Add Go 1.23 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         go-version: 
+          - 1.23.9
           - 1.24.0
           - 1.24.1
           - 1.24.2


### PR DESCRIPTION
WASI support is available since Go 1.21.
I'd add tests for Go 1.23 because 1.21 and 1.22 is no longer supported.
https://go.dev/blog/wasi 